### PR TITLE
Adding close event for previous joinded user

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -14,10 +14,14 @@ navigator.mediaDevices.getUserMedia({
   addVideoStream(myVideo, stream)
 
   myPeer.on('call', call => {
+    peers[call.peer] = call;
     call.answer(stream)
     const video = document.createElement('video')
     call.on('stream', userVideoStream => {
       addVideoStream(video, userVideoStream)
+    })
+    call.on("close", () => {
+        video.remove();
     })
   })
 


### PR DESCRIPTION
When new user join the same group, previou user call is not set on the peer object. so the problem is when previous user is disconnected then the video block is remain same to the user who joind after that, and it never closed until the page is refreshed.